### PR TITLE
Update internal-lb.md

### DIFF
--- a/articles/aks/internal-lb.md
+++ b/articles/aks/internal-lb.md
@@ -6,7 +6,7 @@ author: asudbring
 ms.author: allensu
 ms.subservice: aks-networking
 ms.topic: how-to
-ms.date: 12/11/2024
+ms.date: 03/25/2025
 
 
 #Customer intent: As a cluster operator or developer, I want to learn how to create a service in AKS that uses an internal Azure load balancer for enhanced security and without an external endpoint.
@@ -17,7 +17,7 @@ ms.date: 12/11/2024
 You can create and use an internal load balancer to restrict access to your applications in Azure Kubernetes Service (AKS). An internal load balancer doesn't have a public IP and makes a Kubernetes service accessible only to applications that can reach the private IP. These applications can be within the same VNET or in another VNET through VNET peering. This article shows you how to create and use an internal load balancer with AKS.
 
 > [!IMPORTANT]
-> On September 30, 2025, Basic Load Balancer will be retired. For more information, see the [official announcement](https://azure.microsoft.com/updates/azure-basic-load-balancer-will-be-retired-on-30-september-2025-upgrade-to-standard-load-balancer/). If you're currently using Basic Load Balancer, make sure to upgrade to Standard Load Balancer prior to the retirement date. For guidance on upgrading, visit [Upgrading from Basic Load Balancer - Guidance](/azure/load-balancer/load-balancer-basic-upgrade-guidance).
+> On September 30, 2025, Basic Load Balancer will be retired. For more information, see the [official announcement](https://azure.microsoft.com/updates/azure-basic-load-balancer-will-be-retired-on-30-september-2025-upgrade-to-standard-load-balancer/). At this moment there is no integrated option to use the Azure AKS API operation to migrate the Load Balancer SKU. The Load Balancer SKU decision must be done at cluster creation time. Therefore, if you're currently using Basic Load Balancer, take the necessary steps to migrate your workloads to a new created cluster with the new default Standard Load Balancer SKU prior to the retirement date.
 
 ## Before you begin
 


### PR DESCRIPTION
Updated the IMPORTANT text to remove the reference of the Standalone Load Balancer migration steps. Once the direct changing into the infrastructure resource group is not supported scenario by AKS (FAQ), and avoid any cluster egress issues. There is no AKS API to migrate the Load Balancer SKU so far. Therefore, there is no migration of the Load Balancer SKU. The users must create a new cluster with the default Standard Load Balancer and migrate the workloads.